### PR TITLE
feat: make searchbar functional

### DIFF
--- a/src/components/Drawer/Drawer.vue
+++ b/src/components/Drawer/Drawer.vue
@@ -14,9 +14,6 @@
         <button class="close" @click="drawerVisible = false">&#9587;</button>
       </div>
       <ul class="links-container">
-        <router-link class="routerLink" to="/SearchResults"
-          ><h2>SearchResults</h2></router-link
-        >
         <router-link class="routerLink" to="/About"><h2>About</h2></router-link>
         <router-link class="routerLink" to="/FAQ"><h2>FAQ</h2></router-link>
       </ul>

--- a/src/components/NavBar/NavBar.vue
+++ b/src/components/NavBar/NavBar.vue
@@ -1,7 +1,7 @@
 <template>
   <nav>
     <h6 class="img-container">
-      <router-link to="/" v-if="currentRouteName"
+      <router-link to="/" v-if="currentRouteName" v-on:click="clearSearch"
         ><img src="@/assets/logo_green.png"
       /></router-link>
     </h6>
@@ -21,6 +21,11 @@ export default {
   computed: {
     currentRouteName() {
       return this.$route.name != 'HomePage'
+    },
+  },
+  methods: {
+    clearSearch() {
+      this.$store.commit('updateSearchString', '')
     },
   },
 }

--- a/src/components/SearchBar/SearchBar.test.js
+++ b/src/components/SearchBar/SearchBar.test.js
@@ -1,9 +1,14 @@
 import { shallowMount } from '@vue/test-utils'
 import SearchBar from './SearchBar.vue'
+import store from '../../services/DataService'
 
 describe('SearchBar.vue', () => {
   it('renders the page', () => {
-    const wrapper = shallowMount(SearchBar, {})
+    const wrapper = shallowMount(SearchBar, {
+      global: {
+        plugins: [store],
+      },
+    })
     expect(wrapper.findComponent(SearchBar).exists()).toBe(true)
   })
 })

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -1,14 +1,62 @@
 <template>
-  <div class="input-container">
-    <input class="search" type="text" v-model="SearchString" />
-    <router-link to="/searchresults"
-      ><i class="fa fa-search icon"></i>
-    </router-link>
+  <div>
+    <div class="wrapper">
+      <div class="input-container">
+        <input
+          class="search"
+          type="text"
+          v-model="SearchString"
+          v-on:keyup.enter="checkForSearch"
+        />
+        <router-link to="/searchresults" v-on:click="checkForSearch"
+          ><i class="fa fa-search icon"></i>
+        </router-link>
+      </div>
+    </div>
+    <br />
+    <div class="container">
+      <p>Search on:</p>
+      <div class="radio-container">
+        <input
+          class="radio"
+          type="radio"
+          id="author"
+          value="Author"
+          v-model="picked"
+        />
+        <label for="author">Author</label>
+      </div>
+      <div class="radio-container">
+        <input
+          class="radio"
+          type="radio"
+          id="title"
+          value="Title"
+          v-model="picked"
+        />
+        <label for="title">Title</label>
+      </div>
+      <div class="radio-container">
+        <input
+          class="radio"
+          type="radio"
+          id="journal"
+          value="Journal"
+          v-model="picked"
+        />
+        <label for="journal">Journal</label>
+      </div>
+    </div>
   </div>
 </template>
 <script>
 export default {
   name: 'SearchBar',
+  data() {
+    return {
+      picked: 'Author',
+    }
+  },
   computed: {
     SearchString: {
       get() {
@@ -20,9 +68,16 @@ export default {
     },
   },
   methods: {
-    /* checkForSearch() {
-      this.SearchString=="" ? "/" : "/searchresults"
-    }*/
+    checkForSearch() {
+      if (
+        this.$store.getters.SearchString == '' &&
+        this.$router.name !== 'SearchResults'
+      ) {
+        this.$router.push('/')
+      } else {
+        this.$router.push('/searchresults')
+      }
+    },
   },
   props: {
     Search: String,
@@ -30,6 +85,18 @@ export default {
 }
 </script>
 <style scoped>
+.container,
+.radio-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.radio-container {
+  column-gap: 3px;
+}
+.container {
+  column-gap: 1.5rem;
+}
 .input-container:hover {
   cursor: pointer;
   box-shadow: 1px 1px 5px grey;
@@ -61,7 +128,21 @@ i {
   min-width: 40px;
   color: black;
 }
+label {
+  vertical-align: baseline;
+}
+.radio {
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+  margin: 0;
+}
 .routerLink {
   text-decoration: none;
+}
+.wrapper {
+  display: flex;
+  width: 80vw;
+  justify-content: space-around;
 }
 </style>

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -1,12 +1,32 @@
 <template>
   <div class="input-container">
-    <input class="search" type="text" placeholder="Search" />
-    <i class="fa fa-search icon"></i>
+    <input
+      class="search"
+      type="text"
+      v-model="SearchString"
+    />
+    <router-link to="/searchresults"><i class="fa fa-search icon"></i>
+    </router-link>
   </div>
 </template>
 <script>
 export default {
   name: 'SearchBar',
+  computed: {
+    SearchString: {
+      get() {
+        return this.$store.getters.SearchString
+      },
+      set(value) {
+        this.$store.commit('updateSearchString', value)
+      },
+    },
+  },
+  methods: {
+   /* checkForSearch() {
+      this.SearchString=="" ? "/" : "/searchresults"
+    }*/
+  },
   props: {
     Search: String,
   },
@@ -42,5 +62,9 @@ export default {
 i {
   padding-top: 8px;
   min-width: 40px;
+  color: black;
+}
+.routerLink {
+  text-decoration: none;
 }
 </style>

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -1,11 +1,8 @@
 <template>
   <div class="input-container">
-    <input
-      class="search"
-      type="text"
-      v-model="SearchString"
-    />
-    <router-link to="/searchresults"><i class="fa fa-search icon"></i>
+    <input class="search" type="text" v-model="SearchString" />
+    <router-link to="/searchresults"
+      ><i class="fa fa-search icon"></i>
     </router-link>
   </div>
 </template>
@@ -23,7 +20,7 @@ export default {
     },
   },
   methods: {
-   /* checkForSearch() {
+    /* checkForSearch() {
       this.SearchString=="" ? "/" : "/searchresults"
     }*/
   },

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -10,7 +10,7 @@ const http = axios.create({
 
 const state = {
   SearchString: '',
-  articles: [1, 2, 3],
+  articles: [],
 }
 
 const getters = {
@@ -18,6 +18,7 @@ const getters = {
   articlesSinceYear: (state) => (year) => {
     return state.articles.filter((element) => element.YearPublished >= year)
   },
+  SearchString: (state) => state.SearchString,
 }
 
 const actions = {
@@ -31,6 +32,9 @@ const actions = {
 const mutations = {
   SET_ARTICLES(state, articles) {
     state.articles = articles
+  },
+  updateSearchString(state, SearchString) {
+    state.SearchString = SearchString
   },
 }
 

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -2,7 +2,7 @@ import { createStore } from 'vuex'
 import axios from 'axios'
 
 const http = axios.create({
-  baseURL: 'http://localhost:5000',
+  baseURL: 'http://134.209.134.50:5000/api',
   headers: {
     'Content-type': 'application/json',
   },

--- a/src/views/Home/Home.vue
+++ b/src/views/Home/Home.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="container">
-    <img class="logo" alt="Vue logo" src="../../assets/logo_green.png" />
+    <router-link to="/">
+      <img class="logo" alt="Vue logo" src="../../assets/logo_green.png" />
+    </router-link>
     <div class="wrapper">
       <search-bar />
     </div>

--- a/src/views/Home/Home.vue
+++ b/src/views/Home/Home.vue
@@ -33,11 +33,6 @@ export default {
   align-items: center;
   padding-top: 2rem;
 }
-.wrapper {
-  display: flex;
-  width: 100vw;
-  justify-content: space-around;
-}
 img {
   height: 250px;
 }

--- a/src/views/SearchResults/SearchResults.vue
+++ b/src/views/SearchResults/SearchResults.vue
@@ -78,7 +78,6 @@ export default {
   },
 }
 </script>
-
 <style scoped>
 .container {
   flex-grow: 1;
@@ -89,7 +88,6 @@ export default {
   padding: 1rem;
   justify-content: center;
   align-items: center;
-
   background-color: lightgrey;
 }
 .options-flex-container {
@@ -98,14 +96,12 @@ export default {
   padding: 1rem 5%;
   justify-content: flex-end;
 }
-
 .results-cards-flex-container {
   display: flex;
   flex-direction: column;
   padding: 1rem 5%;
   width: 80%;
 }
-
 .option-select {
   padding: 1rem;
   text-align: left;

--- a/src/views/SearchResults/SearchResults.vue
+++ b/src/views/SearchResults/SearchResults.vue
@@ -1,11 +1,7 @@
 <template>
   <div>
     <div class="container">
-      <h1>Search Results</h1>
-      <p>
-        Short description of what you are looking at, the search term, and
-        possibly a summary bar.
-      </p>
+      <p>Status bar placeholder</p>
     </div>
     <div class="flex-container">
       <div class="options-flex-container">


### PR DESCRIPTION
# Pull Request

## Scope

https://dev.azure.com/JHNMAT015/ECO5037S%20Front%20end/_workitems/edit/137

## Work Done

Making searchbar link to vuex store and redirect to search results either on enter or on click of search icon. Search string stays in search bar after redirect to search page. Routing prevented/redirected on enter or click when text field is empty. When navbar home icon is selected, search text field is cleared.

Addition of radios in preparation of linking search with endpoints.

Cleaned up redundancies: remove placeholder title on search page, also removed navbar search results link.

## Steps to Test

```npm run start```

Navigate through web-pages to check for consistent behaviour in description

## Screenshot
![image](https://user-images.githubusercontent.com/80747408/135245758-dcc94aab-0a6a-47f5-9cdc-e17bdabe182f.png)
